### PR TITLE
Adding PublicIds Parameter for the CloudinaryWrapper->resourcesByIds …

### DIFF
--- a/src/JD/Cloudder/CloudinaryWrapper.php
+++ b/src/JD/Cloudder/CloudinaryWrapper.php
@@ -463,12 +463,13 @@ class CloudinaryWrapper
     /**
      * Show Resources by id
      *
-     * @param  array  $options
+     * @param  array $publicIds
+     * @param  array $options
      * @return array
      */
-    public function resourcesByIds($options = array())
+    public function resourcesByIds($publicIds, $options = array())
     {
-        return $this->getApi()->resources_by_ids($options);
+        return $this->getApi()->resources_by_ids($publicIds, $options);
     }
 
     /**

--- a/tests/CloudinaryWrapperTest.php
+++ b/tests/CloudinaryWrapperTest.php
@@ -366,11 +366,13 @@ class CloudinaryWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $pids = ['pid1', 'pid2'];
 
+        $options = ['test', 'test1'];
+
         // given
-        $this->api->shouldReceive('resources_by_ids')->once()->with($pids);
+        $this->api->shouldReceive('resources_by_ids')->once()->with($pids, $options);
 
         // when
-        $this->cloudinary_wrapper->resourcesByIds($pids);
+        $this->cloudinary_wrapper->resourcesByIds($pids, $options);
     }
 
     /** @test */


### PR DESCRIPTION
…(#49)

* Just a small fix to get the package discovery working

* Fix to the resourcesByIds function wrapping the cloudinary resources_by_ids missing parameter

* Changed the parameter to camel case to be consistent with the rest of the project and made the type of array as the sdk expects

* Adjusted the resources_by_ids test to pass with the new parameter structure